### PR TITLE
Add bank statement import

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import {
 import HomePage from "./pages/HomePage";
 import LoginPage from "./pages/LoginPage";
 import ReflectPage from "./pages/ReflectPage";
+import ImportPage from "./pages/ImportPage";
 import LandingPage from "./pages/LandingPage";
 import { Amplify } from "aws-amplify";
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -35,6 +36,14 @@ const router = createBrowserRouter(
         element={
           <ProtectedRoute>
             <ReflectPage />
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/import"
+        element={
+          <ProtectedRoute>
+            <ImportPage />
           </ProtectedRoute>
         }
       />

--- a/src/components/SideBar.tsx
+++ b/src/components/SideBar.tsx
@@ -201,10 +201,58 @@ export default function SideBar({ refresh }: { refresh: () => void }) {
                     },
               ]}
             />
-          </ListItemButton>
-        </ListItem>
-        <Divider />
-        <List>
+        </ListItemButton>
+      </ListItem>
+      <ListItem disablePadding sx={{ display: "block" }}>
+        <ListItemButton
+          onClick={() => navigate("/import")}
+          sx={[
+            {
+              minHeight: 48,
+              px: 2.5,
+            },
+            open
+              ? {
+                  justifyContent: "initial",
+                }
+              : {
+                  justifyContent: "center",
+                },
+          ]}
+        >
+          <ListItemIcon
+            sx={[
+              {
+                minWidth: 0,
+                justifyContent: "center",
+              },
+              open
+                ? {
+                    mr: 3,
+                  }
+                : {
+                    mr: "auto",
+                  },
+            ]}
+          >
+            <AddIcon />
+          </ListItemIcon>
+          <ListItemText
+            primary="Import"
+            sx={[
+              open
+                ? {
+                    opacity: 1,
+                  }
+                : {
+                    opacity: 0,
+                  },
+            ]}
+          />
+        </ListItemButton>
+      </ListItem>
+      <Divider />
+      <List>
           {bankAccounts?.map((account) => (
             <ListItem
               key={account.name}

--- a/src/hooks/use-history-expense.tsx
+++ b/src/hooks/use-history-expense.tsx
@@ -2,7 +2,7 @@ import { useState, useCallback, useEffect, useMemo } from "react";
 import { generateClient } from "aws-amplify/data";
 import type { Schema } from "../../amplify/data/resource";
 import { useUser } from ".";
-import { HistoryExpense } from "../../amplify/graphql/API";
+import { HistoryExpense, CreateHistoryExpenseInput } from "../../amplify/graphql/API";
 
 export function useListHistoryExpenseByUserId() {
   const { user } = useUser();
@@ -45,4 +45,36 @@ export function useListHistoryExpenseByUserId() {
   }, [listHistoryExpenses]);
 
   return { historyExpenses, listHistoryExpenses, error };
+}
+export function useAddHistoryExpense() {
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+  const { user } = useUser();
+  const { listHistoryExpenses } = useListHistoryExpenseByUserId();
+  const client = generateClient<Schema>({
+    authMode: "userPool",
+  });
+
+  const createHistoryExpense = useCallback(
+    async (input: CreateHistoryExpenseInput) => {
+      if (!user) {
+        return;
+      }
+      try {
+        setSaving(true);
+        await client.models.HistoryExpense.create({
+          ...input,
+          userId: user.sub,
+        });
+        listHistoryExpenses();
+      } catch (err) {
+        setError(err as Error);
+      } finally {
+        setSaving(false);
+      }
+    },
+    [client.models.HistoryExpense, listHistoryExpenses, user],
+  );
+
+  return { saving, createHistoryExpense, error };
 }

--- a/src/pages/ImportPage.tsx
+++ b/src/pages/ImportPage.tsx
@@ -1,0 +1,113 @@
+import React, { useState } from "react";
+import {
+  Box,
+  Button,
+  Typography,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+} from "@mui/material";
+import {
+  useListExpenseTypeByUserId,
+} from "../hooks";
+import { generateClient } from "aws-amplify/data";
+import type { Schema } from "../../amplify/data/resource";
+import { useUser } from "../hooks";
+
+export default function ImportPage(): JSX.Element {
+  const { user } = useUser();
+  const { expenseTypes } = useListExpenseTypeByUserId();
+  const [expenseType, setExpenseType] = useState<string>("");
+  const [loading, setLoading] = useState(false);
+  const client = generateClient<Schema>({ authMode: "userPool" });
+
+  const handleFile = async (file: File) => {
+    if (!user || !expenseType) return;
+    setLoading(true);
+    const ext = file.name.split(".").pop()?.toLowerCase();
+    let rows: Record<string, string>[] = [];
+
+    if (ext === "csv") {
+      const text = await file.text();
+      const lines = text.trim().split(/\r?\n/);
+      const headers = lines[0].split(",");
+      rows = lines.slice(1).map((line) => {
+        const values = line.split(",");
+        const row: Record<string, string> = {};
+        headers.forEach((h, idx) => {
+          row[h.trim()] = values[idx];
+        });
+        return row;
+      });
+    } else if (ext === "xlsx" || ext === "xls") {
+      const mod = await import(
+        "https://cdn.jsdelivr.net/npm/xlsx@0.18.5/+esm"
+      );
+      const array = await file.arrayBuffer();
+      const workbook = mod.read(array, { type: "array" });
+      const sheet = workbook.Sheets[workbook.SheetNames[0]];
+      rows = mod.utils.sheet_to_json(sheet);
+    }
+
+    for (const r of rows) {
+      const amount = parseFloat(r.Amount || r.amount || "0");
+      const date = r.Date || r.date;
+      const description = r.Description || r.description || "Imported";
+      if (!date || isNaN(amount)) continue;
+      const expenseRes = await client.models.Expense.create({
+        name: description,
+        assigned: amount,
+        date: new Date(date).toISOString(),
+        expenseTypeId: expenseType,
+        userId: user.sub,
+      });
+      if (expenseRes?.data?.id) {
+        await client.models.HistoryExpense.create({
+          expenseId: expenseRes.data.id,
+          expenseTypeId: expenseType,
+          date: new Date(date).toISOString(),
+          assigned: amount,
+          userId: user.sub,
+        });
+      }
+    }
+    setLoading(false);
+  };
+
+  const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) {
+      handleFile(file);
+    }
+  };
+
+  return (
+    <Box sx={{ p: 4 }}>
+      <Typography variant="h4" mb={2}>
+        Import Bank Statement
+      </Typography>
+      <FormControl sx={{ minWidth: 200, mb: 2 }}>
+        <InputLabel id="expense-type-label">Expense Type</InputLabel>
+        <Select
+          labelId="expense-type-label"
+          value={expenseType}
+          label="Expense Type"
+          onChange={(e) => setExpenseType(e.target.value as string)}
+        >
+          {expenseTypes?.map((et) => (
+            <MenuItem key={et.id} value={et.id}>
+              {et.name}
+            </MenuItem>
+          ))}
+        </Select>
+      </FormControl>
+      <Box>
+        <Button variant="contained" component="label" disabled={loading || !expenseType}>
+          {loading ? "Uploading..." : "Select File"}
+          <input type="file" hidden onChange={onChange} />
+        </Button>
+      </Box>
+    </Box>
+  );
+}


### PR DESCRIPTION
## Summary
- allow creating history expenses
- add new page to upload CSV and Excel
- navigate to `/import` from sidebar

## Testing
- `yarn lint` *(fails: Couldn't find node_modules state file)*
- `yarn typecheck` *(fails: Couldn't find node_modules state file)*

------
https://chatgpt.com/codex/tasks/task_e_684acaa3ec28832e91171fb9912560f2