### PR TITLE
Fix bankAccount hook typing

### DIFF
--- a/src/hooks/use-bank-account.tsx
+++ b/src/hooks/use-bank-account.tsx
@@ -6,13 +6,12 @@ import {
   CreateBankAccountInput,
   UpdateBankAccountInput,
   DeleteBankAccountInput,
-  BankAccountType,
   BankAccount,
 } from "../../amplify/graphql/API";
 import { useAddHistoryBankAccount } from ".";
 
 export function useBankAccount() {
-  const [bankAccount, setBankAccount] = useState<BankAccountType | null>(null);
+  const [bankAccount, setBankAccount] = useState<BankAccount | null>(null);
   const [error, setError] = useState<Error | null>(null);
 
   // Memoize the client to prevent recreation on every render
@@ -32,7 +31,7 @@ export function useBankAccount() {
           setError(new Error("BankAccount not found"));
           return;
         }
-        setBankAccount(data as unknown as BankAccountType);
+        setBankAccount(data as BankAccount);
       } catch (error) {
         setError(error as Error);
       }


### PR DESCRIPTION
## Summary
- use `BankAccount` as the state type in `useBankAccount`
- simplify casting when setting state

## Testing
- `yarn lint` *(fails: Couldn't find the node_modules state file)*

------
https://chatgpt.com/codex/tasks/task_e_684acaafeb38832e88691c39b96c3237